### PR TITLE
remove date-specific comments about admissions

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,7 +63,7 @@
         <p class="dates dates-p">Two-week sessions throughout the summer</p>
         <p class="dates">June 1st - August 10th.</p>
         <br>
-        <p>The next round of applications are due Saturday, May 30th at 12pm PDT.</p>
+        <p>Applications are currently being accepted on a rolling basis.</p>
       </div>
     </div>
     <div class="summary section text-center">
@@ -83,8 +83,8 @@
           <h3 class="open-sans">When is Hack Camp?</h3>
           <p>
             Hack Camp sessions start every two weeks, beginning June 1st (e.g.
-            June 1st, June 15th, June 29th). Applications are open for the week
-            of June 15th and later.
+            June 1st, June 15th, June 29th). Applications are currently being
+            accepted on a rolling basis.
           </p>
           <hr/>
           <h3 class="open-sans">Where is Hack Camp?</h3>
@@ -102,8 +102,7 @@
           <hr/>
           <h3 class="open-sans">When are applications due?</h3>
           <p>
-            The next round of applications are due Saturday, May 30th at 12pm
-            PDT. We're doing admissions on a rolling basis, so if you've already
+            We're doing admissions on a rolling basis, so if you've already
             applied and haven't heard back from us yet, don't worry! You'll hear
             back from us soon.
           </p>
@@ -317,8 +316,7 @@
           <p class="dates">June 1st - August 10th.</p>
           <br>
           <p class="white">
-            The next round of applications are due Saturday, May 30th at 12pm
-            PDT.
+            Applications are currently being accepted on a rolling basis.
           </p>
         </div>
       </div>


### PR DESCRIPTION
This removes specific sign-up deadlines so we don't have to keep updating them each week.
