### PR TITLE
Adjust hacker arrival to require two leaders

### DIFF
--- a/cohort_4/playbook/ACTIVITIES.md
+++ b/cohort_4/playbook/ACTIVITIES.md
@@ -46,17 +46,17 @@
 
 # Hacker arrival
 
-1. Assign a leader to manage hacker arrival.
-2. Have the assigned leader text all of the hackers the morning of with
+1. Assign two leaders to manage hacker arrival.
+2. Have the assigned leaders text all of the hackers the morning of with
    something along the lines of the following:
 
   > Hey Alice! Can't wait to see you this morning. Just as a quick reminder,
   > the address is 44 Tehama Street in San Francisco. Can you shoot me a text
   > or give me a call when you get here?
 
-3. Have the assigned leader wait in the lobby for arriving hackers.
-4. When a hacker arrives, have the assigned leader guide them down to the
-   hackerspace in the basement, mark their arrival in the
+3. Have the assigned leaders wait in the lobby for arriving hackers.
+4. When a hacker arrives, have one of the assigned leaders guide them down to
+   the hackerspace in the basement, mark their arrival in the
    [attendance sheet](https://docs.google.com/spreadsheets/d/1Em5tUQdm4dXnthtWr4zY4KR9Q6JZMV_Hl2n6G9Ti9Bg/edit),
    and then head back up to the lobby to wait for more arriving hackers.
 


### PR DESCRIPTION
This change adjusts our hacker arrival guidelines to require two leaders.

@MaxWofford can you review/merge this?
