### PR TITLE
Add row to schedule for collecting demo links

### DIFF
--- a/cohort_4/playbook/ACTIVITIES.md
+++ b/cohort_4/playbook/ACTIVITIES.md
@@ -24,6 +24,7 @@
         - [Running it](#running-it)
     - [Maestro](#maestro)
 - [Demos](#demos)
+    - [Links](#links)
     - [First-time demos](#first-time-demos)
     - [Giving feedback](#giving-feedback)
 - [Freeform Projects](#freeform-projects)
@@ -475,6 +476,25 @@ time and effort into for the past day.
   - Make sure to give context by explaining the basic overview of the app and
     why this is a failure
 - After presenting something they failed at, they can show off what they made
+
+## Links
+
+Before kicking off demos, we'll want to collect links to all of the web projects
+from the hackers in the Slack. To do just, just send out a message along the
+lines of the following:
+
+    3:20 PM <zrl> @channel: Hey all! The time has come to collect links to your
+                  projects. If you have a project that works on the web, please
+                  just paste a link to it here. Don't hesitate to ask us for
+                  help doing that!
+
+Ideally all links would be collected by 10 minutes before demos start, giving a
+good buffer if any hackers run into errors getting their projects online.
+
+If their project is not a web project, we recommend using a Google Hangout on
+the computer connected to the projector and the computer they developed on and
+using screen sharing to share their work. It's certainly less than ideal, but it
+has worked in the past.
 
 ## First-time demos
 

--- a/cohort_4/playbook/SCHEDULE.md
+++ b/cohort_4/playbook/SCHEDULE.md
@@ -73,6 +73,7 @@ will be followed by project-time that day.
 | 9:50 AM  | [Energizer 3](ACTIVITIES.md#evolution-rock-paper-scissors)   |
 | 2:00 PM  | [Brainstorming](ACTIVITIES.md#brainstorming)                 |
 | 2:20 PM  | [Project time](ACTIVITIES.md#freeform-projects)              |
+| 3:30 PM  | [Links Collected for demos](ACTIVITIES.md#links)             |
 | 3:40 PM  | [I have failed circle](ACTIVITIES.md#i-have-failed-activity) |
 | 3:50 PM  | [Demos](ACTIVITIES.md#demos)                                 |
 | 4:25 PM  | [Feedback form](ACTIVITIES.md#feedback-forms)                |
@@ -91,6 +92,7 @@ Day layout copied from [here](../prep/meetings/15-07-27_sprint_discuss.md).
 | 12:30 PM | [Lunch](ACTIVITIES.md#lunch)                                 |
 | 1:30 PM  | Energizer                                                    |
 | 2:00 PM  | [Project time](ACTIVITIES.md#freeform-projects)              |
+| 3:50 PM  | [Links Collected for demos](ACTIVITIES.md#links)             |
 | 4:00 PM  | [Demos](ACTIVITIES.md#demos)                                 |
 | 4:25 PM  | [Feedback form](ACTIVITIES.md#feedback-forms)                |
 | 4:30 PM  | [Hack cheer](ACTIVITIES.md#finishing-off-the-day)            |
@@ -106,6 +108,7 @@ Day layout copied from [here](../prep/meetings/15-07-27_sprint_discuss.md).
 | 12:30 PM | [Lunch](ACTIVITIES.md#lunch)                                 |
 | 1:30 PM  | Energizer                                                    |
 | 2:00 PM  | Project time                                                 |
+| 3:50 PM  | [Links Collected for demos](ACTIVITIES.md#links)             |
 | 4:00 PM  | Demos                                                        |
 | 4:25 PM  | [Feedback form](ACTIVITIES.md#feedback-forms)                |
 | 4:30 PM  | [Hack cheer](ACTIVITIES.md#finishing-off-the-day)            |
@@ -121,6 +124,7 @@ Day layout copied from [here](../prep/meetings/15-07-27_sprint_discuss.md).
 | 12:30 PM | [Lunch](ACTIVITIES.md#lunch)                                 |
 | 1:30 PM  | Energizer                                                    |
 | 2:00 PM  | Project time                                                 |
+| 3:50 PM  | [Links Collected for demos](ACTIVITIES.md#links)             |
 | 4:00 PM  | Demos                                                        |
 | 4:25 PM  | [Feedback form](ACTIVITIES.md#feedback-forms)                |
 | 4:30 PM  | [Hack cheer](ACTIVITIES.md#finishing-off-the-day)            |


### PR DESCRIPTION
This change adds guidelines for collecting demo links and links to the
guidelines from the schedule. Closes #330.
