### PR TITLE
Update day 3 energizers

### DIFF
--- a/cohort_4/playbook/ACTIVITIES.md
+++ b/cohort_4/playbook/ACTIVITIES.md
@@ -10,11 +10,11 @@
     - [Human Knot](#human-knot)
     - [Human Pictionary](#human-pictionary)
     - [I Love My Neighbor Who](#i-love-my-neighbor-who)
+    - [Mumbled Messages](#mumbled-messages)
     - [Ninja](#ninja)
     - [One Word Radio](#one-word-radio)
     - [Sharks and Minnows](#sharks-and-minnows)
     - [Slow Motion Samurai](#slow-motion-samurai)
-    - [Telephone](#telephone)
     - [Where The West Wind Blows](#where-the-west-wind-blows)
 - [Introduction talk](#introduction-talk)
     - [Speaking from personal experience.](#speaking-from-personal-experience)
@@ -286,6 +286,30 @@ Number: best for 10-35
   think "could only apply to them" and when they realize when it applies to
   someone else, bonding happens.
 
+## Mumbled Messages
+
+```
+Time: 10 minutes
+Materials: none
+Number: unknown
+Source: unknown
+```
+
+Mumbled Messages is a game where you try to pass around a message and compare
+how it is at the beginning and at the end. People are standing in a circle and
+the message gets passed around in the clockwise direction.
+
+Start by having one person, Person A, think of a complicated phrase to say to
+the person on his or her left, Person B. Person A will then whisper that message
+into Person B's ear, and Person B will whisper the message he heard into Person
+C's ear, and so on, until the message gets around to the person on Person A's
+right hand side, Person X. Person X will then say the phrase he thinks he heard,
+and then Person A will say his phrase. Then the group will see how accurate
+Person X's phrase was.
+
+The energizer typically ends after one round (the message has been passed all
+around), but more rounds can be run if necessary.
+
 ## Ninja
 
 ```
@@ -396,30 +420,6 @@ are moving too fast and massacring many other players, simply tell them to slow
 down.
 
 This energizer usually ends when there is a large pile of bodies on the floor.
-
-## Telephone
-
-```
-Time: 10 minutes
-Materials: none
-Number: unknown
-Source: unknown
-```
-
-Telephone is a game where you try to pass around a message and compare how it is
-at the beginning and at the end. People are standing in a circle and the message
-gets passed around in the clockwise direction.
-
-Start by having one person, Person A, think of a complicated phrase to say to
-the person on his or her left, Person B. Person A will then whisper that message
-into Person B's ear, and Person B will whisper the message he heard into Person
-C's ear, and so on, until the message gets around to the person on Person A's
-right hand side, Person X. Person X will then say the phrase he thinks he heard,
-and then Person A will say his phrase. Then the group will see how accurate
-Person X's phrase was.
-
-The energizer typically ends after one round (the message has been passed all
-around), but more rounds can be run if necessary.
 
 ## Where The West Wind Blows
 

--- a/cohort_4/playbook/ACTIVITIES.md
+++ b/cohort_4/playbook/ACTIVITIES.md
@@ -262,8 +262,8 @@ Source: unknown
 ```
 
 Mumbled Messages is a game where you try to pass around a message and compare
-how it is at the beginning and at the end. People are standing in a circle and
-the message gets passed around in the clockwise direction.
+how it is at the beginning and at the end. People stand in a circle and the
+message gets passed around in the clockwise direction.
 
 Start by having one person, Person A, think of a complicated phrase to say to
 the person on his or her left, Person B. Person A will then whisper that message

--- a/cohort_4/playbook/ACTIVITIES.md
+++ b/cohort_4/playbook/ACTIVITIES.md
@@ -6,7 +6,6 @@
 - [Energizers](#energizers)
     - [Bad startup ideas](#bad-startup-ideas)
     - [Evolution Rock Paper Scissors](#evolution-rock-paper-scissors)
-    - [Fortunately, Unfortunately](#fortunately-unfortunately)
     - [Human Knot](#human-knot)
     - [Human Pictionary](#human-pictionary)
     - [I Love My Neighbor Who](#i-love-my-neighbor-who)
@@ -14,7 +13,6 @@
     - [Ninja](#ninja)
     - [One Word Radio](#one-word-radio)
     - [Sharks and Minnows](#sharks-and-minnows)
-    - [Slow Motion Samurai](#slow-motion-samurai)
     - [Where The West Wind Blows](#where-the-west-wind-blows)
 - [Introduction talk](#introduction-talk)
     - [Speaking from personal experience.](#speaking-from-personal-experience)
@@ -180,38 +178,6 @@ chicken1 - chicken6, egg2 - egg3, while chicken4 and egg5 wait for partners.
 Then when people lose, an example scenario is: egg1, monkey6, chicken2,
 egg3, chicken4, and egg5.  This continues until there are a specific number
 of divine beings you decide upon.
-
-## Fortunately, Unfortunately
-
-```
-Time: 5 - 10 minutes
-Materials: none
-Number: unknown
-Sources:
-
-- http://wiki.improvresourcecenter.com/index.php/Fortunately,_Unfortunately
-- http://www.bringyourownimprov.com/games.htm
-```
-
-_Fortunately, Unfortunately_ is a verbal warmup. Players stand in a circle. One
-player states a phrase from the first-person. The person to his left then says
-either "Fortunately," and then gives a positive aspect of the previously
-mentioned event, or says "Unfortunately," and gives a negative aspect. Then the
-next person to the left says "Fortunately" if the previously person said
-"Unfortunately," and vice versa. Play continues around the circle.
-
-Example:
-
-- A: "One upon a time Mary had a beautiful little lamb"
-- B: "Unfortunately, the lamb had a peg leg"
-- C: "Fortunately, Mary opened the leg and the lamb produced Skittles"
-- A: "Unfortunately, Skittles were illegal in Greece, where they lived, and Mary
-  and the lamb were sent to farmer's prison"
-
-This energizer usually ends once everyone in the circle has gone once or twice,
-depending on the size of the group. Use digression when ending and make sure to
-announce early who will be the last to speak (ex. saying "John Snow will be the
-last in this round!").
 
 ## Human Knot
 
@@ -395,31 +361,6 @@ Number: unknown
 - If a minnow is tagged by a shark, the minnow is now kelp and cannot move.
 - Kelp will try to reach out and tag the minnows as they run past. If a minnow
   is tagged by kelp, it also becomes kelp.
-
-## Slow Motion Samurai
-
-```
-Time: 5 - 10 minutes
-Materials: none
-Number: unknown
-Source: http://learnimprov.com/?p=169
-```
-
-Start with having everyone mill around the room (walk around in a crowd-like
-fashion). Once people are nice and moving, tell them to start moving in slow
-motion.
-
-Once a stable speed of slow motion is determined, the players all become samurai
-with poisonous blades build into their forearms. The object is to kill all the
-other samurai in the room.
-
-If anyone is touched by the forearm of another player, they must die a poisoned
-death in slow motion. It is important that the players keep their speed
-continuous. The point is not to win the energizer, but to have fun. If players
-are moving too fast and massacring many other players, simply tell them to slow
-down.
-
-This energizer usually ends when there is a large pile of bodies on the floor.
 
 ## Where The West Wind Blows
 

--- a/cohort_4/playbook/SCHEDULE.md
+++ b/cohort_4/playbook/SCHEDULE.md
@@ -111,14 +111,13 @@ partners. Please do make sure to explain _why_ we are assigning hackers (explain
 | Time     | Activity                                                     |
 | -------- | ------------------------------------------------------------ |
 | 9:00 AM  | [Hackers start arriving](ACTIVITIES.md#hacker-arrival)       |
-| 9:20 AM  | [Energizer 1](ACTIVITIES.md#fortunately-unfortunately)       |
-| 9:30 AM  | [Energizer 2](ACTIVITIES.md#slow-motion-samurai)             |
+| 9:20 AM  | [Energizer 1](ACTIVITIES.md#mumbled-messages)                |
+| 9:30 AM  | [Energizer 2](ACTIVITIES.md#ninja)                           |
 | 9:40 AM  | [Morning Announcements](ACTIVITIES.md#morning-announcements) |
 | 9:45 AM  | [Breakfast](ACTIVITIES.md#breakfast)                         |
 | 10:00 AM | [Maestro workshop](ACTIVITIES.md#maestro)                    |
 | 12:30 PM | [Lunch](ACTIVITIES.md#lunch)                                 |
-| 1:30 PM  | [Energizer 3](ACTIVITIES.md#human-pictionary)                |
-| 1:45 PM  | [Energizer 4](ACTIVITIES.md#ninja)                           |
+| 1:30 PM  | [Energizer 3](ACTIVITIES.md#human-knot)                      |
 | 2:00 PM  | [Project Formation](ACTIVITIES.md#project-formation)         |
 | 2:30 PM  | [Project time](ACTIVITIES.md#freeform-projects)              |
 | 3:50 PM  | [Links collected for demos](ACTIVITIES.md#links)             |


### PR DESCRIPTION
This change updates the energizers in day 3's schedule to what was actually run and renames the _Telephone_ energizer to _Mumbled Messages_. It also removes the Fortunately, Unfortunately and Slow Motion Samurai energizers.

Closes #349.

@MaxWofford can you review/merge this?
