### PR TITLE
Add 'Who are we?' section to summary

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -1,6 +1,10 @@
 body {
   background: whitesmoke; }
 
+a {
+  color: #ff4b55;
+}
+
 .title {
   padding: 100px 0;
   color: whitesmoke;

--- a/index.html
+++ b/index.html
@@ -102,6 +102,18 @@
           need-based financial aid (see the question on the application form).
         </p>
       </div>
+      <div class='small-11 medium-8 large-6 small-centered'>
+        <hr>
+        <h2>
+          Who are we?
+        </h2>
+        <p>
+          <a href="https://hackclub.com/">Hack Club</a> is a San Francisco-based
+          nonprofit that brings coding clubs to highschools around the globe.
+          Over this summer we'll be running Hack Camp to spread beyond just the
+          high school setting.
+        </p>
+      </div>
     </div>
     <div class='row text-center section testimony'>
       <div class='small-12 medium-8 medium-centered columns'>


### PR DESCRIPTION
This is a duplicate of #556, except it has the changes from #561 rebased in to make it easy to see the visual impact of @MaxWofford's change.
