### PR TITLE
Trick Percy into thinking gh-pages is master

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,4 +4,9 @@ dependencies:
 
 test:
   override:
-    - percy snapshot --widths "375,1280" .
+    - |
+      if [ "$CIRCLE_BRANCH" = "gh-pages" ]; then
+        PERCY_PREFIX="PERCY_BRANCH=master"
+      fi
+
+      $PERCY_PREFIX percy snapshot --widths "375,1280" .


### PR DESCRIPTION
This pull request _should_ fix our Percy woes. Right now Percy likes to diff new pull requests with the last pull request submitted, instead of against the `gh-pages` branch. I reached out to support and while they don't support setting Percy's default branch to anything other than `master` yet, they said that we can do this workaround for the time being.
