### PR TITLE
*Actually* fix PERCY_BRANCH usage

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -6,7 +6,7 @@ test:
   override:
     - |
       if [ "$CIRCLE_BRANCH" = "gh-pages" ]; then
-        PERCY_BRANCH="master"
+        export PERCY_BRANCH="master"
       fi
 
       percy snapshot --widths "375,1280" .


### PR DESCRIPTION
My previous fix didn't allow PERCY_BRANCH to by accessed by the percy-cli subprocess, which is totally my bad.
